### PR TITLE
修复点击“文章目录”切换TOC伸缩时，fa-caret三角形图标指向不正确的问题

### DIFF
--- a/source/js/toc.js
+++ b/source/js/toc.js
@@ -66,12 +66,12 @@ define(function (){
             $tocTitle.click(function(){
                 if ($subToc.is(":hidden")) {
                     $subToc.show(150);
-                    $iconToExpand.removeClass("hide");
-                    $iconToFold.addClass("hide");
-                } else {
-                    $subToc.hide(100);
                     $iconToExpand.addClass("hide");
                     $iconToFold.removeClass("hide");
+                } else {
+                    $subToc.hide(100);
+                    $iconToExpand.removeClass("hide");
+                    $iconToFold.addClass("hide");
                 }
             })
             // TOC on mobile


### PR DESCRIPTION
修复点击“文章目录”切换TOC伸缩时，fa-caret三角形图标指向不正确的问题。
应该展开时向下，收起时向右，原顺序是反的。