### PR TITLE
fix issue #148 -firefox下左边栏ul偏移

### DIFF
--- a/source/css/_partial/main.styl
+++ b/source/css/_partial/main.styl
@@ -153,7 +153,7 @@
         float: none;
         min-height: @line-height * 3;
         max-height: @line-height * 5;
-        overflow: auto;
+        overflow: visible;
         text-align: center;
         display: -webkit-box;
         -webkit-box-orient: horizontal;


### PR DESCRIPTION
修正左边栏ul和li在firefox浏览器下向左偏移的问题。 问题产生的环境：ubuntu16.04 firefox 49.0
原因是overflow的属性为auto，在firefox浏览器中会产生偏移，因此置为默认的visible，不影响其他效果。