### PR TITLE
Fix addthis share toolbox issue

### DIFF
--- a/layout/_partial/comments/disqus.ejs
+++ b/layout/_partial/comments/disqus.ejs
@@ -17,7 +17,7 @@
 </section>
 
 <% if (!theme.preload_comment) { %>
-    // Add comment count
+    <!-- // Add comment count -->
     <script id="dsq-count-scr" src="//<%= shortname%>.disqus.com/count.js" async></script>
     <span class="disqus-comment-count" data-disqus-identifier="<%= page.path %>"></span>
     <span class="disqus-comment-count" data-disqus-url="<%= page.permalink %>"></span>

--- a/layout/_partial/post/share.ejs
+++ b/layout/_partial/post/share.ejs
@@ -17,7 +17,7 @@
     <% } %>
 
     <% if (theme.share.addthis) { %>
-        <div class="addthis_sharing_toolbox"></div>
+        <div class="addthis_inline_share_toolbox"></div>
     <% } %>
 </div>
 


### PR DESCRIPTION
* This is also [issue#7 in the repo MOxFIVE/yelee](https://github.com/MOxFIVE/yelee/issues/7)
* Change `<div class="addthis_sharing_toolbox"></div>` to `<div class="addthis_inline_share_toolbox"></div>`
* if we use an inline addthis share toolbox (which is generally the case we will use in this yelee theme), we have to make the above change or the toolbox we built ourselves won't show up.

* 这也是 MOxFIVE/yelee 仓库里的[issue#7](https://github.com/MOxFIVE/yelee/issues/7)，必须按照如上修改，否则我们自己新建立的 addthis share toolbox 会无法显示