### PR TITLE
修复404在非根目录下错误链接，导致style.css无法正确获取

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -42,7 +42,7 @@
     <link href="//cdn.bootcss.com/pace/1.0.2/themes/<%= theme.progressBar.color || 'blue'%>/pace-theme-<%= theme.progressBar.type || 'minimal'%>.css" rel="stylesheet">
 <% } %>
 
-<%- css('css/style') %>
+<%- css('/css/style') %>
 
 <% if (is_home() && theme.animate){ %>
     <style> .article { opacity: 0;} </style>


### PR DESCRIPTION
在404.html文件中，生成如下样式为正确：
\<link rel="stylesheet" href="/css/style.css">
而我的环境中生成的是：
\<link rel="stylesheet" href="css/style.css">
导致在https://userName.github.io/blog/a/dfssdfsdfs.html这样错误连接中，实际请求的http连接是https://userName.github.io/blog/a/css/style.css而获取不到style.css显示错乱。

hexo环境：
![image](https://cloud.githubusercontent.com/assets/17882645/22558427/9cb78a56-e9a8-11e6-8045-460d0e167403.png)

[官方对css辅助函数的说法](https://hexo.io/zh-cn/docs/helpers.html#css)
