### PR TITLE
Add reward 增加文章打赏功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -286,6 +286,13 @@ progressBar:
   type: "minimal"  # Keep Quotes | 保留引号避免出错
   color: blue
 
+# 文章末尾是否显示打赏按钮
+donate:
+  #on: true
+  reward_comment: 哎呦，不行了，要睡觉了，赏我 e(=2.72) 元咖啡钱吧，您的支持将鼓励我继续创作！
+  wechatpay: /img/wechat-reward-qr.png
+  alipay: /img/alipay-reward-qr.png
+
 CDN:
   jquery: //cdn.bootcss.com/jquery/2.2.4/jquery.min.js
   require: //cdn.bootcss.com/require.js/2.2.0/require.min.js

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -55,6 +55,9 @@
   <% if (!index){ %>
     <%- partial('post/nav') %>
   <% } %>
+  <% if (!index && theme.donate){ %>
+    <%- partial('donate') %>
+  <% } %>
 </article>
 <%- partial('_partial/toc') %>
 

--- a/layout/_partial/donate.ejs
+++ b/layout/_partial/donate.ejs
@@ -1,0 +1,28 @@
+<% if (theme.donate.on) { %>
+    <div style="padding: 0; margin: 20px auto; width: 90%; text-align: center;">
+      <br>
+      <div><%=theme.donate.reward_comment%></div>
+      <br>
+      <button id="rewardButton" disable="enable" onclick="var qr = document.getElementById('QR'); if (qr.style.display === 'none') {qr.style.display='block';} else {qr.style.display='none'}">
+        <div class="btn btn-pay">打赏支持</div>
+      </button>
+      <br>
+      <br>
+      <div id="QR" style="display: none;">
+        <% if (theme.donate.wechatpay) { %>
+          <div id="wechat" style="display: inline-block;">
+            <img id="wechat_qr" src="<%=theme.donate.wechatpay%>" alt="<%=theme.author%> WeChat Pay"/>
+            <p>微信打赏</p>
+          </div>
+        <% } %>
+        <% if (theme.donate.alipay) { %>
+          <div id="alipay" style="display: inline-block">
+            <img id="alipay_qr" src="<%=theme.donate.alipay%>" alt="<%=theme.author%> Alipay"/>
+            <p>支付宝打赏</p>
+          </div>
+        <% } %>
+        <br>
+        <br>
+      </div>
+    </div>
+<% } %>

--- a/source/css/_partial/donate.styl
+++ b/source/css/_partial/donate.styl
@@ -1,0 +1,38 @@
+#rewardButton {
+    background-color: #ea6f5a;
+}
+
+.btn-pay {
+    margin-bottom: 20px;
+    padding: 8px 25px;
+    font-size: 16px;
+    color: #fff;
+    background-color: #ea6f5a;
+}
+
+.btn {
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: 400;
+    text-align: center;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857;
+    border-radius: 4px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+#QR img{
+    height: 200px;
+    height: 200px;
+    margin: 20px;
+}

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -2,7 +2,7 @@
 @import "_variables"
 @import "_util/mixin"
 @import "_util/grid"
-@import "_partial/sidebar"
+@import "_partial/donate"
 
 global-reset()
 

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -2,6 +2,7 @@
 @import "_variables"
 @import "_util/mixin"
 @import "_util/grid"
+@import "_partial/sidebar"
 
 global-reset()
 


### PR DESCRIPTION
- **修改主题配置文件_config.yml中的donate使能控制是否打赏**：

```
# 文章末尾是否显示打赏按钮
donate:
  #on: true
  reward_comment: 哎呦，不行了，要睡觉了，赏我 e(=2.72) 元咖啡钱吧，您的支持将鼓励我继续创作！
  wechatpay: /img/wechat-reward-qr.png
  alipay: /img/alipay-reward-qr.png
```

- 打赏通过donate->on使能的true和false控制；
- 打赏配文自定义；
- 支持微信和支付宝二维码打赏，给出二维码地址即可；
- 打赏功能代码单独分模块`layout/_partial/donate.ejs` 和 `source/css/_partial/donate.styl`控制，不影响原始代码，具体显示样式可以方便修改css和ejs文件，根据自己喜好可以设置按钮为打赏图标；
- PC，移动端显示均良好。

打赏效果图示例：

- 默认不显示二维码：

![](http://zhwhong.ml/images/reward_click_before.png)

- 点击打赏按钮后显示二维码：

![](http://zhwhong.ml/images/reward_click_after.png)

效果可以看我的博客：https://zhwhong.cn